### PR TITLE
Upgraded to F# 4.0 (FSharp.Core 4.4) everywhere

### DIFF
--- a/Fabel.sln
+++ b/Fabel.sln
@@ -5,6 +5,14 @@ VisualStudioVersion = 14.0.24720.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabel", "src\Fabel.fsproj", "{486D9B44-99FB-436F-9F5D-0F685453E14C}"
 EndProject
+Project("{F2A71F9B-5D33-465A-A702-920D77279786}") = "Fabel.Tests", "test\Fabel.Tests.fsproj", "{6EF06954-FBDF-42C7-815C-B13BA2926C93}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{0FE9BBC0-4866-444E-A429-C30CEDB7C03C}"
+	ProjectSection(SolutionItems) = preProject
+		tools\fabel2babel.js = tools\fabel2babel.js
+		tools\typescript2fabel.js = tools\typescript2fabel.js
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -15,6 +23,10 @@ Global
 		{486D9B44-99FB-436F-9F5D-0F685453E14C}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{486D9B44-99FB-436F-9F5D-0F685453E14C}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{486D9B44-99FB-436F-9F5D-0F685453E14C}.Release|Any CPU.Build.0 = Release|Any CPU
+		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{6EF06954-FBDF-42C7-815C-B13BA2926C93}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/Fabel.fsproj
+++ b/src/Fabel.fsproj
@@ -10,7 +10,7 @@
     <AssemblyName>Fabel</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>Fabel</Name>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
@@ -40,7 +40,7 @@
     <Reference Include="System" />
     <Reference Include="System.Core" />
     <Reference Include="System.Numerics" />
-    <Reference Include="FSharp.Core">
+    <Reference Include="FSharp.Core, Version=$(TargetFSharpCoreVersion), Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
       <Private>True</Private>
     </Reference>
   </ItemGroup>

--- a/src/Util.fs
+++ b/src/Util.fs
@@ -110,14 +110,3 @@ module Json =
             | _, [|v|] -> serializer.Serialize(writer, v) 
             | _ -> writer.WriteNull()        
 
-module List =
-  let rec last = function
-    | hd :: [] -> hd
-    | hd :: tl -> last tl
-    | _ -> failwith "Empty list."
-  let singleton (a:'c) =
-     [a]
-  let where f (a:List<'c>) =
-    a |> List.toSeq |> Seq.where f |> Seq.toList
-  let take count (a:List<'c>) =
-    a |> List.toSeq |> Seq.take count |> Seq.toList

--- a/test/Fabel.Tests.fsproj
+++ b/test/Fabel.Tests.fsproj
@@ -10,8 +10,9 @@
     <RootNamespace>Fabel.Tests</RootNamespace>
     <AssemblyName>Fabel.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <TargetFSharpCoreVersion>4.3.1.0</TargetFSharpCoreVersion>
+    <TargetFSharpCoreVersion>4.4.0.0</TargetFSharpCoreVersion>
     <Name>Fabel.Tests</Name>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
build using FSharp 4.4
FSharp.Core with the same version referenced
List module functions removed as already in FSharp.Core
Tests are green now